### PR TITLE
Display dropdown on focus even for AJAX requests

### DIFF
--- a/jquery.tokenize.js
+++ b/jquery.tokenize.js
@@ -158,7 +158,7 @@
 
             this.searchInput.on('focus click', function(){
                 $this.tokensContainer.addClass('Focused');
-                if($this.options.displayDropdownOnFocus && $this.options.datas == 'select'){
+                if($this.options.displayDropdownOnFocus){
                     $this.search();
                 }
             });


### PR DESCRIPTION
The displayDropdownOnLoad option currently only works for "select" data source. Would like it to also work for AJAX data sources, and just make a request to the server with a search value of "".
